### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Seeed Studio
 maintainer=Seeed Studio <techsupport@seeed.cc>
 sentence=Arduino library of 16-Channel Servo Driver
 paragraph=Arduino library of 16-Channel Servo Driver
-category=Actuators
+category=Device Control
 url=https://github.com/Seeed-Studio/Seeed_PCA9685
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Actuators' in library Seeed-PCA9685 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format