### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,8 +5,8 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-PCA9685  KEYWORD1
-ServoDriver  KEYWORD1
+PCA9685	KEYWORD1
+ServoDriver	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -14,7 +14,7 @@ ServoDriver  KEYWORD1
 init	KEYWORD2
 setServoPulseRange	KEYWORD2
 setAngle	KEYWORD2
-setPwm 	KEYWORD2
+setPwm	KEYWORD2
 setFrequency	KEYWORD2
 reset	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords